### PR TITLE
Adding error parsing as per TODO

### DIFF
--- a/src/odrive_ros/odrive_interface.py
+++ b/src/odrive_ros/odrive_interface.py
@@ -179,19 +179,6 @@ class ODriveInterfaceAPI(object):
         if not self.driver:
             return None
             
-        axis_error = self.axes[0].error or self.axes[1].error
-
-        if axis_error:
-            return dump_errors(self.driver, clear=clear)
-        
-        if clear:
-            for axis in self.axes:
-                axis.error = 0
-                axis.motor.error = 0
-                axis.encoder.error = 0
-                axis.controller.error = 0
-        
-        
-        
+        return dump_errors(self.driver, clear=clear)
         
         

--- a/src/odrive_ros/odrive_interface.py
+++ b/src/odrive_ros/odrive_interface.py
@@ -8,6 +8,7 @@ import traceback
 
 import odrive
 from odrive.enums import *
+from odrive.utils import dump_errors
 
 import fibre
 
@@ -179,6 +180,9 @@ class ODriveInterfaceAPI(object):
             return None
             
         axis_error = self.axes[0].error or self.axes[1].error
+
+        if axis_error:
+            return dump_errors(self.driver, clear=clear)
         
         if clear:
             for axis in self.axes:
@@ -187,8 +191,7 @@ class ODriveInterfaceAPI(object):
                 axis.encoder.error = 0
                 axis.controller.error = 0
         
-        if axis_error:
-            return "error"
+        
         
         
         


### PR DESCRIPTION
Removing old logic and replacing with most recent version of odrivetool's `dump_error()`

Example python interactive script runs:

```
>>> od.get_errors(clear=True)
Axis0:
  axis: no error
  motor: no error
  encoder: no error
  controller: no error
Axis1:
  axis: no error
  motor: no error
  encoder: no error
  controller: no error

```


```
>>> od.calibrate(
... )
Vbus 48.33V
Calibrating axis 0...
Calibrating axis 1...
Failed calibration with axis error 0x40, motor error 0x1
False
>>> od.get_errors()
Axis0:
  axis: no error
  motor: no error
  encoder: no error
  controller: no error
Axis1:
  axis: Error(s):
    ERROR_MOTOR_FAILED
  motor: Error(s):
    ERROR_PHASE_RESISTANCE_OUT_OF_RANGE
  encoder: no error
  controller: no error
>>> od.preroll
```